### PR TITLE
Chore: Add Standard SSoT Pre-Commit Hooks - update tooling configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,119 +1,46 @@
-# SSoT: gcs-devops-standards/tooling/configs/.pre-commit-config.yaml
-# Version: 1.0
-# Author: Camille (Gem AB - Automation Specialist)
-# Based on: TOOL_004_Git_Hooks_Standard.md and GenCr@ft Studio requirements
-
-# For global hook versions, refer to pre-commit documentation or specific hook repositories for latest stable tags.
-# Periodically run `pre-commit autoupdate` in a central management repo to propose updates to these `rev` values.
-
-# Consider running on `push` as well for more rigorous checks on certain hooks if desired.
-# default_stages: [commit, push]
+# ===================================================================
+# Gencraft Studio - Canonical Pre-Commit Configuration v1.0
+# SSoT: gcs-devops-standards/.pre-commit-config.yaml
+# ===================================================================
 
 repos:
-  # ===== Generic File Checks (Highly Recommended) =====
+  # ===== Generic File Checks =====
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0 # Using a recent stable tag
+    rev: v5.0.0
     hooks:
-      - id: check-added-large-files # Prevent committing large binary files
-        args: ['--maxkb=1024'] # Max 1MB. Adjust for art asset repos (e.g., gcp-aethel-assets-*)
-      - id: check-case-conflict # Check for files that would conflict on case-insensitive filesystems
-      - id: check-executables-have-shebangs
-      - id: check-json # Check JSON file syntax
-      - id: check-merge-conflict # Check for files that contain merge conflict strings
-      - id: check-shebang-scripts-are-executable # Ensures scripts with shebangs are executable
-      - id: check-symlinks # Check for symlinks that might not be portable
-      - id: check-toml # Check TOML file syntax
-      - id: check-xml # Check XML file syntax
-      - id: check-yaml # Check YAML file syntax
-        args: [--allow-multiple-documents]
-      - id: detect-private-key # Detects the presence of private keys (AWS keys, SSH keys, etc.)
-      - id: end-of-file-fixer # Ensures files end with one newline and only one
-      - id: mixed-line-ending # Replaces mixed line endings with a consistent one (LF by default)
-      - id: trailing-whitespace # Trims trailing whitespace
+      - id: check-added-large-files
+        args: ['--maxkb=1024']
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: check-json
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  # ===== Commit Message Validation =====
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.22.0
+    hooks:
+    - id: commitlint
+      stages: [commit-msg]
+      additional_dependencies: ["@commitlint/config-conventional"]
 
   # ===== Markdown Linting =====
-  # Requires .markdownlint.yaml at the root of the repo using this.
-  # SSoT for .markdownlint.yaml config: devops-standards/linting/configs/.markdownlint.yaml (to be created/verified)
-  # References: GCT-TOOL-MDLINT-V1.md
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.41.0 
+    rev: v0.45.0
     hooks:
       - id: markdownlint
-        name: "Markdownlint"
-        description: "Lints Markdown files using .markdownlint.yaml config."
-        entry: markdownlint --config .markdownlint.yaml --fix .
-        # Runs on all staged markdown files. --fix attempts auto-correction.
+        args: ["--config", ".markdownlint.yaml"]
 
-  # ===== Shell Script Linting =====
-  # References: SCRIPT_001_General_Scripting_Standard.md
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+  # ===== Gencraft SSoT Linters (Custom Hooks) =====
+  - repo: https://github.com/GenCr-ft/gcd-ops-scripts.git
+    rev: v2.6.0
     hooks:
-      - id: shellcheck
-        name: "ShellCheck"
-        description: "Static analysis for shell scripts (.sh, .bash)."
-        args: ["-x"]  # To follow sourced files
-
-  # ===== OpenTofu/Terraform Linting & Formatting =====
-  # Requires OpenTofu installed and configured in the environment.
-  # References: IAC_001_OpenTofu_Tooling_Standard.md, IAC_007_IaC_Static_Analysis_Standard.md
-  - repo: local
-    hooks:
-      - id: opentofu-fmt
-        name: "OpenTofu Format (tofu fmt -check)"
-        description: "Checks if OpenTofu (.tf, .tfvars) files are correctly formatted."
-        entry: bash -c 'files=$(git diff --cached --name-only --diff-filter=ACM "*.tf" "*.tfvars"); [ -z "$files" ] || (echo "$files" | xargs -r dirname | sort -u | xargs -I {} tofu -chdir={} fmt -check -diff)'
-        language: system
-        files: (\.tf|\.tfvars)$
-        pass_filenames: false
-      - id: opentofu-validate
-        name: "OpenTofu Validate (tofu validate)"
-        description: "Validates OpenTofu configuration files in directories with a backend.tf."
-        # This hook runs `tofu init` (for provider download) and `tofu validate`
-        # It's more reliable to run this in directories that are actual OpenTofu root modules.
-        entry: bash -c 'dirs=$(git ls-files -m -o --exclude-standard -- "*.tf" "*.tfvars" | xargs -r dirname | sort -u); for dir in $dirs; do if [ -f "$dir/backend.tf" ] || [ -f "$dir/main.tf" ]; then (echo "Validating Tofu in $dir" && cd "$dir" && tofu init -backend=false -upgrade && tofu validate -no-color) || exit 1 ; fi; done'
-        language: system
-        files: \.tf$ # Triggers if any .tf file is staged
-        pass_filenames: false
-
-  # ===== Commit Message Linting (via commit-msg hook) =====
-  # Requires Node.js, npm/npx, and commitlint installed.
-  # Onboarding scripts should handle commitlint setup.
-  # commitlint.config.js SSoT: devops-standards/tooling/configs/commitlint.config.js
-  # References: TOOL_001_Conventional_Commits_Standard.md
-  - repo: local
-    hooks:
-      - id: commitlint
-        name: "Commitlint"
-        entry: npx commitlint --edit $1 # $1 is the file containing the commit message
-        language: node 
-        stages: [commit-msg]
-
-  # ===== Python Linting & Formatting (Example - Uncomment and adapt if Python projects are common) =====
-  # Requires Python, pip, black, flake8.
-  # - repo: https://github.com/psf/black-pre-commit-mirror
-  #   rev: 24.4.2 # Check for latest stable tag
-  #   hooks:
-  #   - id: black
-  #     # args: ["--config=pyproject.toml"] # If black config is in pyproject.toml
-  #     language_version: python3.9 # Specify your project's Python version
-  # - repo: https://github.com/PyCQA/flake8
-  #   rev: 7.1.0 # Check for latest stable tag
-  #   hooks:
-  #   - id: flake8
-  #     # args: ["--config=.flake8"] # If you have a .flake8 config file
-
-  # ===== JavaScript/TypeScript Linting & Formatting (Example - Uncomment and adapt if used) =====
-  # Requires Node.js, npm/npx, eslint, prettier.
-  # - repo: https://github.com/pre-commit/mirrors-eslint
-  #   rev: v9.7.0 # Check for latest stable tag
-  #   hooks:
-  #     - id: eslint
-  #       # args: ["--fix"]
-  #       types: [javascript, jsx, ts, tsx]
-  # - repo: https://github.com/pre-commit/mirrors-prettier
-  #   rev: v3.1.0 # Check for latest stable tag. Note: Prettier v4 is ESM only.
-  #   hooks:
-  #     - id: prettier
-  #       # args: ["--config=.prettierrc.yaml"]
-  #       # types_or: [javascript, jsx, ts, tsx, json, css, scss, html, yaml, markdown] # Adjust types
+      - id: metadata-linter
+        name: SSoT Metadata Linter
+        exclude: ^(tests/fixtures/|integration_test_docs/|README\.md)
+      - id: naming-linter
+        name: SSoT Naming Linter
+        exclude: ^(tests/fixtures/|integration_test_docs/|README\.md)
+      - id: link-linter
+        name: SSoT Link Linter
+        exclude: ^(tests/fixtures/|integration_test_docs/|README\.md)

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,83 @@
+// Gencraft Standard commitlint.config.js (v1.2 - Approved)
+// SSoT: devops-standards/tooling/configs/commitlint.config.js
+// This configuration enforces Gencraft's Conventional Commits standard (TOOL_001_Conventional_Commits_Standard.md).
+// It should be placed at the root of each repository using commitlint (typically via pre-commit).
+// See [https://commitlint.js.org/#/reference-rules](https://commitlint.js.org/#/reference-rules) for all rule options.
+
+module.exports = {
+  // Extend from the conventional config, which provides good defaults based on Angular's convention.
+  extends: ['@commitlint/config-conventional'],
+
+  // Define Gencraft specific rules or override defaults here.
+  // Rule configuration: [Level, Applicable, Value]
+  // Level: 0-disable, 1-warning, 2-error
+  // Applicable: "always" | "never"
+  // Value: Varies per rule (string, number, array, etc.)
+
+  rules: {
+    // --- Type ---
+    // Types allowed MUST be strictly aligned with TOOL_001_Conventional_Commits_Standard.md.
+    // An AI Gem (Édouard or Camille) can be prompted to sync this list with TOOL_001.
+    'type-enum': [
+      2, // Level: Error - The commit will be rejected if the type is not in this list.
+      'always', // Applicable: The type must always be one of the values in the array.
+      [ // Value: Allowed types. Descriptions are for human reference.
+        'feat',       // A new feature
+        'fix',        // A bug fix
+        'docs',       // Documentation only changes
+        'style',      // Changes that do not affect the meaning of the code (white-space, formatting, etc)
+        'refactor',   // A code change that neither fixes a bug nor adds a feature
+        'perf',       // A code change that improves performance
+        'test',       // Adding missing tests or correcting existing tests
+        'build',      // Changes that affect the build system or external dependencies
+        'ci',         // Changes to our CI configuration files and scripts
+        'chore',      // Other changes that don't modify src or test files
+        'revert',     // Reverts a previous commit
+      ],
+    ],
+
+    // --- Subject ---
+    // Enforce that the subject is not empty.
+    'subject-empty': [2, 'never'],
+    // Enforce that the subject does not end with a period.
+    'subject-full-stop': [2, 'never', '.'],
+    // Warn if the subject exceeds 72 characters.
+    // 'subject-max-length': [
+    //   1, // Level: Warning - Discourage overly long subjects.
+    //   'always',
+    //   72  // Max length. TOOL_001 recommends a soft limit of 50 and a hard limit of 72.
+    //       // This provides a warning at 72. Strive for 50.
+    // ],
+
+    // --- Header (Type, Scope, Subject) ---
+    // Max length for the entire header line (e.g., "feat(scope): subject").
+    'header-max-length': [2, 'always', 100], // Hard limit for the header line.
+
+    // --- Body ---
+    // The body provides additional contextual information about the code changes.
+    'body-leading-blank': [
+      1, // Level: Warning - A blank line between subject and body improves readability.
+      'always'
+    ],
+    'body-max-line-length': [
+      1, // Level: Warning - Encourage wrapping body lines for readability.
+      'always',
+      100
+    ],
+
+    // --- Footer ---
+    // Footer is used for metadata like "BREAKING CHANGE:" or "Refs: #ISSUE-ID".
+    'footer-leading-blank': [
+      1, // Level: Warning - A blank line between body and footer improves readability.
+      'always'
+    ],
+    'footer-max-line-length': [
+      1, // Level: Warning - Encourage wrapping footer lines.
+      'always',
+      100
+    ],
+
+    // --- Signed-off-by (Gencraft does not use DCO/signed-off-by) ---
+    'signed-off-by': [0, 'always', 'Signed-off-by:'], // Disabled
+  },
+};


### PR DESCRIPTION
This PR automatically adds the canonical SSoT pre-commit configuration from `gcs-devops-standards` to enforce documentation quality standards.