### PR TITLE
Chore: Add Standard SSoT Pre-Commit Hooks - update tooling configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 # ===================================================================
 # Gencraft Studio - Canonical Pre-Commit Configuration v1.0
 # SSoT: gcs-devops-standards/.pre-commit-config.yaml
@@ -10,19 +11,97 @@ repos:
     hooks:
       - id: check-added-large-files
         args: ['--maxkb=1024']
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
       - id: check-merge-conflict
+      - id: check-case-conflict
       - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-xml
+      - id: check-toml
       - id: check-json
       - id: end-of-file-fixer
+      - id: detect-private-key # Detects the presence of private keys
+      - id: mixed-line-ending # Replaces mixed line endings with a consistent one (LF by default)
       - id: trailing-whitespace
+
+  # ===== Security Scanning (Secrets) =====
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+
+  # ===== Documentation Quality (Spelling) =====
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        # Exclure les fichiers qui peuvent contenir des faux positifs
+        exclude: .*\.lock|pyproject.toml|.*\.js
+
+  # ===== YAML Linting =====
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args: ['--config-file', '.yamllint.yaml']
+
+  # ===== Python Linting & Formatting (Ruff) =====
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.5
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  # == Shell Script Linting ==
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1 # Check for latest stable tag
+    hooks:
+      - id: shellcheck
+        name: "Shellcheck"
+        description: "Static analysis for shell scripts."
+        # args: ["-x"]  # To follow sourced files
+
+  # == OpenTofu/Terraform Linting & Formatting ==
+  # Requires OpenTofu installed.
+  - repo: local
+    hooks:
+      - id: opentofu-fmt
+        name: "OpenTofu Format (tofu fmt)"
+        description: "Formats OpenTofu HCL files."
+        entry: bash -c 'tofu fmt -recursive $(git ls-files -m -o --exclude-standard "*.tf" | xargs dirname | sort -u)'
+        language: system
+        files: \.tf$
+        # This runs fmt on directories containing staged .tf files.
+        # A simpler alternative is to run on all .tf files, but can be slow.
+        # entry: tofu fmt -check -recursive . # Use -check for linting, remove for formatting
+      - id: opentofu-validate
+        name: "OpenTofu Validate (tofu validate)"
+        description: "Validates OpenTofu configuration files."
+        entry: bash -c 'tofu validate -no-color' # Run in each directory with .tf files or main dir
+        language: system
+        files: \.tf$ # Or run once per commit if it traverses
+        pass_filenames: false # Usually validate runs on the whole configuration
+        # This hook needs careful scoping if you have multiple independent Tofu configs in one repo.
+        # Often better run in CI or per-directory manually.
+
+  # ===== JavaScript/TypeScript Linting =====
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.9.0
+    hooks:
+      - id: eslint
+        types: [javascript, ts, tsx]
+        # Note: Requires a .eslintrc.js config file in the repo.
 
   # ===== Commit Message Validation =====
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.22.0
     hooks:
-    - id: commitlint
-      stages: [commit-msg]
-      additional_dependencies: ["@commitlint/config-conventional"]
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional"]
 
   # ===== Markdown Linting =====
   - repo: https://github.com/igorshubovych/markdownlint-cli
@@ -33,14 +112,11 @@ repos:
 
   # ===== Gencraft SSoT Linters (Custom Hooks) =====
   - repo: https://github.com/GenCr-ft/gcd-ops-scripts.git
-    rev: v2.6.0
+    rev: v2.5.3 # Utiliser le dernier tag stable de nos outils
     hooks:
       - id: metadata-linter
-        name: SSoT Metadata Linter
-        exclude: ^(tests/fixtures/|integration_test_docs/|README\.md)
+        exclude: &ssot_exclude ^(tests/fixtures/|integration_test_docs/|README\.md)
       - id: naming-linter
-        name: SSoT Naming Linter
-        exclude: ^(tests/fixtures/|integration_test_docs/|README\.md)
+        exclude: *ssot_exclude
       - id: link-linter
-        name: SSoT Link Linter
-        exclude: ^(tests/fixtures/|integration_test_docs/|README\.md)
+        exclude: *ssot_exclude


### PR DESCRIPTION
This PR automatically adds the canonical SSoT pre-commit configuration from `gcs-devops-standards` to enforce documentation quality standards.