### PR TITLE
CI: Add Global SSoT Linter Workflow

### DIFF
--- a/.github/workflows/ssot-compliance.yml
+++ b/.github/workflows/ssot-compliance.yml
@@ -1,0 +1,17 @@
+# SSoT Compliance Check
+# This workflow calls the central, reusable SSoT linter.
+# DO NOT add logic here. To update the linter, modify the reusable workflow in gcd-shared-actions.
+name: SSoT Compliance Check
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  ssot-linting:
+    # This calls the master workflow from the correct SSoT location.
+    # The '@main' should be replaced with a specific version tag (e.g., @v1.0) for production stability.
+    uses: GenCr-ft/gcd-shared-actions/.github/workflows/reusable-ssot-linter.yml@main
+    with:
+      # We keep the default behavior which is to fail the job on error.
+      continue-on-error: false

--- a/.github/workflows/ssot-compliance.yml
+++ b/.github/workflows/ssot-compliance.yml
@@ -11,7 +11,9 @@ jobs:
   ssot-linting:
     # This calls the master workflow from the correct SSoT location.
     # The '@main' should be replaced with a specific version tag (e.g., @v1.0) for production stability.
-    uses: GenCr-ft/gcd-shared-actions/.github/workflows/reusable-ssot-linter.yml@main
+    uses: GenCr-ft/gcd-shared-actions/.github/workflows/reusable-ssot-linter.yml@v1.1.2
+    secrets:
+      CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}
     with:
       # We keep the default behavior which is to fail the job on error.
       continue-on-error: false


### PR DESCRIPTION
This PR introduces the standardized, reusable SSoT compliance check. It calls the master workflow from `gcd-shared-actions` to ensure all future contributions are validated against our governance standards as defined in GOV-STANDARD-008.