### PR TITLE
ci: bump ssot-linter to v1.3.1 (self-hosted runner)

### DIFF
--- a/.github/workflows/ssot-compliance.yml
+++ b/.github/workflows/ssot-compliance.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Run Official SSoT Linter"
     # This calls the master workflow from the correct SSoT location.
     # The '@main' should be replaced with a specific version tag (e.g., @v1.0) for production stability.
-    uses: GenCr-ft/gcd-shared-actions/.github/workflows/reusable-ssot-linter.yml@v1.2.5
+    uses: GenCr-ft/gcd-shared-actions/.github/workflows/reusable-ssot-linter.yml@v1.3.1
     secrets:
       CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}
     with:


### PR DESCRIPTION
Bumps `reusable-ssot-linter.yml` pin from `@v1.2.5` → `@v1.3.1`.

`v1.3.1` migrates the reusable workflow runner from `ubuntu-latest` to `[self-hosted, linux, x64]`, eliminating the GitHub billing error on all SSoT Compliance jobs.

Part of: GenCr-ft/gcd-shared-actions#38