### PR TITLE
ci(ssot-compliance): issue-123 — flip link_linter to hard gate

### DIFF
--- a/.github/workflows/ssot-compliance.yml
+++ b/.github/workflows/ssot-compliance.yml
@@ -16,8 +16,8 @@ jobs:
     secrets:
       CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}
     with:
-      # We keep the default behavior which is to fail the job on error.
-      continue-on-error: true
+      # Hard gate: repo is clean (0 broken links) — refs gcs-devops-standards#123.
+      continue-on-error: false
       # We specify the exact, stable versions of our governance and tooling.
       governance-version: "v1.4.0"
       tooling-version: "v4.1.2"

--- a/.github/workflows/ssot-compliance.yml
+++ b/.github/workflows/ssot-compliance.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Run Official SSoT Linter"
     # This calls the master workflow from the correct SSoT location.
     # The '@main' should be replaced with a specific version tag (e.g., @v1.0) for production stability.
-    uses: GenCr-ft/gcd-shared-actions/.github/workflows/reusable-ssot-linter.yml@v1.2.5
+    uses: GenCr-ft/gcd-shared-actions/.github/workflows/reusable-ssot-linter.yml@v1.3.1
     secrets:
       CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}
     with:


### PR DESCRIPTION
This repo has 0 broken relative links (verified by link_linter audit 2026-06-02). Promoting from advisory to hard gate.

Refs GenCr-ft/gcs-devops-standards#123