### PR TITLE
ci(ssot-compliance): issue-123 — bump reusable linter @v1.3.1 → @v1.3.2

### DIFF
--- a/.github/workflows/ssot-compliance.yml
+++ b/.github/workflows/ssot-compliance.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Run Official SSoT Linter"
     # This calls the master workflow from the correct SSoT location.
     # The '@main' should be replaced with a specific version tag (e.g., @v1.0) for production stability.
-    uses: GenCr-ft/gcd-shared-actions/.github/workflows/reusable-ssot-linter.yml@v1.3.1
+    uses: GenCr-ft/gcd-shared-actions/.github/workflows/reusable-ssot-linter.yml@v1.3.2
     secrets:
       CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}
     with:


### PR DESCRIPTION
Corrects undeclared version bump from PR #10 (was @v1.3.1, canonical is @v1.3.2 per the studio sweep).

Refs GenCr-ft/gcs-devops-standards#123